### PR TITLE
k8sprocessor: add host.name and container.name fields

### DIFF
--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -70,15 +70,15 @@ func TestLoadConfig(t *testing.T) {
 			Passthrough: false,
 			Extract: ExtractConfig{
 				Metadata: []string{
-					"podName",
-					"podUID",
-					"deployment",
 					"cluster",
+					"containerName",
+					"deployment",
+					"hostName",
 					"namespace",
 					"node",
+					"podName",
+					"podUID",
 					"startTime",
-					"hostName",
-					"containerName",
 				},
 				Annotations: []FieldExtractConfig{
 					{TagName: "a1", Key: "annotation-one"},

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -41,23 +41,26 @@ func TestLoadConfig(t *testing.T) {
 	config, err := configtest.LoadConfigFile(
 		t,
 		path.Join(".", "testdata", "config.yaml"),
-		factories)
+		factories,
+	)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, config)
 
 	p0 := config.Processors["k8s_tagger"]
-	assert.Equal(t, p0,
+	assert.Equal(t,
 		&Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "k8s_tagger",
 				NameVal: "k8s_tagger",
 			},
 			APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
-		})
+		},
+		p0,
+	)
 
 	p1 := config.Processors["k8s_tagger/2"]
-	assert.Equal(t, p1,
+	assert.Equal(t,
 		&Config{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "k8s_tagger",
@@ -66,7 +69,17 @@ func TestLoadConfig(t *testing.T) {
 			APIConfig:   k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
 			Passthrough: false,
 			Extract: ExtractConfig{
-				Metadata: []string{"podName", "podUID", "deployment", "cluster", "namespace", "node", "startTime"},
+				Metadata: []string{
+					"podName",
+					"podUID",
+					"deployment",
+					"cluster",
+					"namespace",
+					"node",
+					"startTime",
+					"hostName",
+					"containerName",
+				},
 				Annotations: []FieldExtractConfig{
 					{TagName: "a1", Key: "annotation-one"},
 					{TagName: "a2", Key: "annotation-two", Regex: "field=(?P<value>.+)"},
@@ -89,5 +102,7 @@ func TestLoadConfig(t *testing.T) {
 					{Key: "key2", Value: "value2", Op: "not-equals"},
 				},
 			},
-		})
+		},
+		p1,
+	)
 }

--- a/processor/k8sprocessor/kube/client_test.go
+++ b/processor/k8sprocessor/kube/client_test.go
@@ -323,6 +323,15 @@ func TestExtractionRules(t *testing.T) {
 		},
 		Spec: api_v1.PodSpec{
 			NodeName: "node1",
+			Hostname: "myhostname",
+			Containers: []api_v1.Container{
+				{
+					Name: "container-zzzzz",
+				},
+				{
+					Name: "sidecar-container-aaaaa",
+				},
+			},
 		},
 		Status: api_v1.PodStatus{
 			PodIP: "1.1.1.1",
@@ -348,13 +357,15 @@ func TestExtractionRules(t *testing.T) {
 	}, {
 		name: "metadata",
 		rules: ExtractionRules{
-			Deployment: true,
-			Namespace:  true,
-			PodName:    true,
-			PodUID:     true,
-			Node:       true,
-			Cluster:    true,
-			StartTime:  true,
+			Deployment:    true,
+			Namespace:     true,
+			PodName:       true,
+			PodUID:        true,
+			Node:          true,
+			Cluster:       true,
+			StartTime:     true,
+			HostName:      true,
+			ContainerName: true,
 		},
 		attributes: map[string]string{
 			"k8s.deployment.name": "auth-service",
@@ -364,6 +375,8 @@ func TestExtractionRules(t *testing.T) {
 			"k8s.pod.name":        "auth-service-abc12-xyz3",
 			"k8s.pod.uid":         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 			"k8s.pod.startTime":   pod.GetCreationTimestamp().String(),
+			"container.name":      "container-zzzzz,sidecar-container-aaaaa",
+			"host.name":           "myhostname",
 		},
 	}, {
 		name: "labels",

--- a/processor/k8sprocessor/kube/kube.go
+++ b/processor/k8sprocessor/kube/kube.go
@@ -102,13 +102,15 @@ type FieldFilter struct {
 // ExtractionRules is used to specify the information that needs to be extracted
 // from pods and added to the spans as tags.
 type ExtractionRules struct {
-	Deployment bool
-	Namespace  bool
-	PodName    bool
-	PodUID     bool
-	Node       bool
-	Cluster    bool
-	StartTime  bool
+	Deployment    bool
+	Namespace     bool
+	PodName       bool
+	PodUID        bool
+	Node          bool
+	Cluster       bool
+	StartTime     bool
+	HostName      bool
+	ContainerName bool
 
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -31,13 +31,15 @@ const (
 	filterOPExists       = "exists"
 	filterOPDoesNotExist = "does-not-exist"
 
-	metdataNamespace   = "namespace"
-	metadataPodName    = "podName"
-	metadataPodUID     = "podUID"
-	metadataStartTime  = "startTime"
-	metadataDeployment = "deployment"
-	metadataCluster    = "cluster"
-	metadataNode       = "node"
+	metadataNamespace     = "namespace"
+	metadataPodName       = "podName"
+	metadataPodUID        = "podUID"
+	metadataStartTime     = "startTime"
+	metadataDeployment    = "deployment"
+	metadataCluster       = "cluster"
+	metadataNode          = "node"
+	metadataHostName      = "hostName"
+	metadataContainerName = "containerName"
 )
 
 // Option represents a configuration option that can be passes.
@@ -68,18 +70,20 @@ func WithExtractMetadata(fields ...string) Option {
 	return func(p *kubernetesprocessor) error {
 		if len(fields) == 0 {
 			fields = []string{
-				metdataNamespace,
+				metadataNamespace,
 				metadataPodName,
 				metadataPodUID,
 				metadataStartTime,
 				metadataDeployment,
 				metadataCluster,
 				metadataNode,
+				metadataHostName,
+				metadataContainerName,
 			}
 		}
 		for _, field := range fields {
 			switch field {
-			case metdataNamespace:
+			case metadataNamespace:
 				p.rules.Namespace = true
 			case metadataPodName:
 				p.rules.PodName = true
@@ -93,6 +97,10 @@ func WithExtractMetadata(fields ...string) Option {
 				p.rules.Cluster = true
 			case metadataNode:
 				p.rules.Node = true
+			case metadataHostName:
+				p.rules.HostName = true
+			case metadataContainerName:
+				p.rules.ContainerName = true
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
 			}

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -70,37 +70,37 @@ func WithExtractMetadata(fields ...string) Option {
 	return func(p *kubernetesprocessor) error {
 		if len(fields) == 0 {
 			fields = []string{
+				metadataCluster,
+				metadataContainerName,
+				metadataDeployment,
+				metadataHostName,
 				metadataNamespace,
+				metadataNode,
 				metadataPodName,
 				metadataPodUID,
 				metadataStartTime,
-				metadataDeployment,
-				metadataCluster,
-				metadataNode,
-				metadataHostName,
-				metadataContainerName,
 			}
 		}
 		for _, field := range fields {
 			switch field {
+			case metadataCluster:
+				p.rules.Cluster = true
+			case metadataContainerName:
+				p.rules.ContainerName = true
+			case metadataDeployment:
+				p.rules.Deployment = true
+			case metadataHostName:
+				p.rules.HostName = true
 			case metadataNamespace:
 				p.rules.Namespace = true
+			case metadataNode:
+				p.rules.Node = true
 			case metadataPodName:
 				p.rules.PodName = true
 			case metadataPodUID:
 				p.rules.PodUID = true
 			case metadataStartTime:
 				p.rules.StartTime = true
-			case metadataDeployment:
-				p.rules.Deployment = true
-			case metadataCluster:
-				p.rules.Cluster = true
-			case metadataNode:
-				p.rules.Node = true
-			case metadataHostName:
-				p.rules.HostName = true
-			case metadataContainerName:
-				p.rules.ContainerName = true
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
 			}

--- a/processor/k8sprocessor/options_test.go
+++ b/processor/k8sprocessor/options_test.go
@@ -205,6 +205,8 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.True(t, p.rules.Deployment)
 	assert.True(t, p.rules.Cluster)
 	assert.True(t, p.rules.Node)
+	assert.True(t, p.rules.HostName)
+	assert.True(t, p.rules.ContainerName)
 
 	p = &kubernetesprocessor{}
 	err := WithExtractMetadata("randomfield")(p)
@@ -219,6 +221,8 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.False(t, p.rules.StartTime)
 	assert.False(t, p.rules.Deployment)
 	assert.False(t, p.rules.Node)
+	assert.False(t, p.rules.HostName)
+	assert.False(t, p.rules.ContainerName)
 }
 
 func TestWithFilterLabels(t *testing.T) {

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -9,15 +9,15 @@ processors:
     extract:
       metadata:
         # extract the following well-known metadata fields
-        - podName
-        - podUID
-        - deployment
         - cluster
+        - containerName
+        - deployment
+        - hostName
         - namespace
         - node
+        - podName
+        - podUID
         - startTime
-        - hostName
-        - containerName
 
       annotations:
         - tag_name: a1 # extracts value of annotation with key `annotation-one` and inserts it as a tag with key `a1`

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -16,6 +16,8 @@ processors:
         - namespace
         - node
         - startTime
+        - hostName
+        - containerName
 
       annotations:
         - tag_name: a1 # extracts value of annotation with key `annotation-one` and inserts it as a tag with key `a1`


### PR DESCRIPTION
**Description:**

This PR adds option to tag data with `host.name` and `container.name` fields.