### PR TITLE
Update ec2.go

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -74,7 +74,7 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 	attr := res.Attributes()
 	attr.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
 	attr.InsertString("cloud.infrastructure_service", "EC2")
-	attr.InsertString("cloud.namespace", "ec2")
+	attr.InsertString("cloud.namespace", "aws/ec2")
 	attr.InsertString(conventions.AttributeCloudRegion, meta.Region)
 	attr.InsertString(conventions.AttributeCloudAccount, meta.AccountID)
 	attr.InsertString(conventions.AttributeCloudZone, meta.AvailabilityZone)

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -136,7 +136,7 @@ func TestDetector_Detect(t *testing.T) {
 				attr.InsertString("cloud.account.id", "account1234")
 				attr.InsertString("cloud.provider", "aws")
 				attr.InsertString("cloud.infrastructure_service", "EC2")
-				attr.InsertString("cloud.namespace", "ec2")
+				attr.InsertString("cloud.namespace", "aws/ec2")
 				attr.InsertString("cloud.region", "us-west-2")
 				attr.InsertString("cloud.zone", "us-west-2a")
 				attr.InsertString("host.id", "i-abcd1234")


### PR DESCRIPTION
TRACING-1684 | Change cloud.namespace tag from "ec2" to "aws/ec2".