### PR TITLE
Fix opentelemetry collector builder Github Action

### DIFF
--- a/.github/workflows/opentelemetry-collector-builder.yaml
+++ b/.github/workflows/opentelemetry-collector-builder.yaml
@@ -6,16 +6,44 @@ on:
       - main
 
 jobs:
-  otelcolbuilder:
+  # otelcolbuilder_post_go1_16:
+  #   runs-on: ubuntu-20.04
+  #   strategy:
+  #     matrix:
+  #       go: [ '1.16' ]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup go
+  #       uses: actions/setup-go@v2
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #     - name: Print go version
+  #       run: go version
+  #     - name: Build OpenTelemetry distro
+  #       working-directory: ./otelcolbuilder/
+  #       run: |
+  #         go install github.com/open-telemetry/opentelemetry-collector-builder@v0.24.0
+  #         make build
+
+  # Just build on 1.15 for now because of a weird issue:
+  # https://github.com/actions/setup-go/issues/107
+  otelcolbuilder_pre_go1_16:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.15', '1.14' ]
+        go: [ '1.15' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
+      - name: Print go version
+        run: go version
+      - name: Print go env
+        run: go env
+      - name: Build OpenTelemetry distro
         working-directory: ./otelcolbuilder/
-        run: make build
+        run: |
+          make install-prego1.16
+          make build

--- a/otelcolbuilder/Makefile
+++ b/otelcolbuilder/Makefile
@@ -1,5 +1,8 @@
 install:
 	go install github.com/open-telemetry/opentelemetry-collector-builder@v0.24.0
 
-build: install
+install-prego1.16:
+	GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder@v0.24.0
+
+build:
 	opentelemetry-collector-builder --config .otelcol-builder.yaml


### PR DESCRIPTION
Fix github action introduces in https://github.com/SumoLogic/opentelemetry-collector-contrib/pull/1300

```
.github/workflows/opentelemetry-collector-builder.yaml : .github#L1
a step cannot have both the `uses` and `run` keys
```